### PR TITLE
Feature/type components

### DIFF
--- a/lib/fenrir/version.rb
+++ b/lib/fenrir/version.rb
@@ -1,3 +1,3 @@
 module Fenrir
-  VERSION = "0.1.8.3"
+  VERSION = "0.1.8.4"
 end

--- a/vendor/assets/stylesheets/fenrir/configs/defaults.scss
+++ b/vendor/assets/stylesheets/fenrir/configs/defaults.scss
@@ -204,7 +204,7 @@ $title-font: $charlie-font !default;
 $body-font: $charlie-font !default;
 $mono-font: monospace !default;
 
-$type-line-height: 1.4em !default;
+$type-line-height: 1.5 !default;
 
 // ( mobile, tablet+, line-height )
 $type-objects: (

--- a/vendor/assets/stylesheets/fenrir/configs/defaults.scss
+++ b/vendor/assets/stylesheets/fenrir/configs/defaults.scss
@@ -205,33 +205,17 @@ $mono-font: monospace !default;
 
 
 // ( mobile, tablet+ )
-$type-sizes: (
-  'heading-1': (87px, 100px),
-  'heading-2': (65px, 75px),
-  'heading-3': (49px, 56px),
-  'heading-4': (37px, 42px),
-  'heading-5': (28px, 32px),
-  'heading-6': (21px, 24px),
-  'body':      (16px, 18px),
-  'note':      (12px, 13px),
-) !default;
-
-
-// (size, line-height, weight, text-transform, opacity)
 $type-variants: (
-  'display-300':  ('heading-1', 1.2em, 0, 400, capitalize, 1),
-  'display-200':  ('heading-2', 1.2em, 0, 400, capitalize, 1),
-  'display':      ('heading-3', 1.2em, 0, 400, capitalize, 1),
+  'display-300':  (87px, 100px),
+  'display-200':  (65px, 75px),
+  'display':      (49px, 56px),
 
-  'headline':     ('heading-4', 1.2em, 0, 400, capitalize, 1),
-  'title':        ('heading-5', 1.2em, 0, 400, capitalize, 1),
-  'lead':         ('heading-6', 1.2em, 0, 400, none, 1),
-  'body':         ('body', 1.5em, 1em, 400, none, 0.85),
-  'product':      ('body', 1em, 0, 400, none, 1),
+  'headline':     (37px, 42px),
+  'title':        (28px, 32px),
+  'lead':         (21px, 24px),
+  'body':         (16px, 18px),
 
-  'note':         ('note', 1em, 0, 400, none, 0.7),
-  'label':        ('note', 1em, 0, 700, uppercase, 0.7),
-  'caption':      ('note', 1em, 0, 400, uppercase, 0.7),
+  'note':         (12px, 13px),
 ) !default;
 
 

--- a/vendor/assets/stylesheets/fenrir/configs/defaults.scss
+++ b/vendor/assets/stylesheets/fenrir/configs/defaults.scss
@@ -63,6 +63,7 @@ $spacing-properties: (
 ) !default;
 
 
+
 //-----------------------------------//
 // States
 //-----------------------------------//
@@ -73,6 +74,7 @@ $states: (
   'warning': 'has-warning',
   'error':   'has-error',
 ) !default;
+
 
 
 //-----------------------------------//
@@ -92,6 +94,7 @@ $z-layers: (
 ) !default;
 
 
+
 //-----------------------------------//
 // Setup bootstrap grid framework
 //-----------------------------------//
@@ -107,7 +110,6 @@ $grid-breakpoints: (
   xl: 1200px  // Extra large screen / wide desktop
 ) !default;
 
-
 // Grid containers
 // Define the maximum width of `.container` for different screen sizes.
 $container-max-widths: (
@@ -117,11 +119,10 @@ $container-max-widths: (
   xl: 1140px
 ) !default;
 
-
 // Grid columns
 // Set the number of columns and specify the width of the gutters.
-$grid-columns:               12 !default;
-$grid-gutter-width:          1.875rem !default; // 30px
+$grid-columns:      12 !default;
+$grid-gutter-width: 1.875rem !default; // 30px
 
 
 
@@ -203,21 +204,21 @@ $title-font: $charlie-font !default;
 $body-font: $charlie-font !default;
 $mono-font: monospace !default;
 
+$type-line-height: 1.4em !default;
 
-// ( mobile, tablet+ )
-$type-variants: (
-  'display-300':  (87px, 100px),
-  'display-200':  (65px, 75px),
-  'display':      (49px, 56px),
+// ( mobile, tablet+, line-height )
+$type-objects: (
+  'display-300': (87px, 100px),
+  'display-200': (65px, 75px),
+  'display':     (49px, 56px),
 
-  'headline':     (37px, 42px),
-  'title':        (28px, 32px),
-  'lead':         (21px, 24px),
-  'body':         (16px, 18px),
+  'headline':    (37px, 42px),
+  'title':       (28px, 32px),
+  'lead':        (21px, 24px),
+  'body':        (16px, 18px),
 
-  'note':         (12px, 13px),
+  'note':        (12px, 13px),
 ) !default;
-
 
 $type-colors: (
   'primary':      color('primary'),
@@ -236,19 +237,16 @@ $type-colors: (
   'inherit':      inherit,
 ) !default;
 
-
 $type-alignments: (
   'left':   left,
   'center': center,
   'right':  right,
 ) !default;
 
-
 $type-weights: (
   'normal': 400,
   'bold': 700,
 ) !default;
-
 
 $type-families: (
   'charlie': $charlie-font,

--- a/vendor/assets/stylesheets/fenrir/mixins/_color_generators.scss
+++ b/vendor/assets/stylesheets/fenrir/mixins/_color_generators.scss
@@ -26,7 +26,7 @@
         }
       }
     } @else {
-      @warn 'Using deprecated variable definition. $background-colors should have values of lists (background color, text color)';
+      // @warn 'Using deprecated variable definition. $background-colors should have values of lists (background color, text color)';
 
       &--#{$variant} {
         background: $value;

--- a/vendor/assets/stylesheets/fenrir/mixins/_type_generators.scss
+++ b/vendor/assets/stylesheets/fenrir/mixins/_type_generators.scss
@@ -4,27 +4,19 @@
 //-----------------------------------\\
 // Typography generation
 //-----------------------------------\\
-// @include o-text-size--('heading-1');
 // @include o-text--('display');
 //-----------------------------------\\
 
-@mixin o-text-size--($variant) {
+@mixin o-text--($variant) {
+  color: inherit;
   font-size: type-size($variant, 1);
+  line-height: $type-line-height;
+  opacity: 1;
+  margin-bottom: 0;
 
   @include media-breakpoint-up(md) {
     font-size: type-size($variant, 2);
   }
-}
-
-@mixin o-text--($variant) {
-  @include o-text-size--(type-variant($variant, 1));
-
-  color: inherit;
-  line-height: type-variant($variant, 2);
-  margin-bottom: type-variant($variant, 3);
-  font-weight: type-variant($variant, 4);
-  text-transform: type-variant($variant, 5);
-  opacity: type-variant($variant, 6);
 }
 
 
@@ -33,7 +25,7 @@
 // Typography generation
 //-----------------------------------\\
 
-@mixin gen-type-hierarchy($variants: $type-variants) {
+@mixin gen-type-hierarchy($variants: $type-objects) {
   @each $size in map-keys($variants) {
     .o-text--#{$size} {
       @include o-text--($size);

--- a/vendor/assets/stylesheets/fenrir/objects/typography.scss
+++ b/vendor/assets/stylesheets/fenrir/objects/typography.scss
@@ -8,6 +8,11 @@
 @if $generate-type-hierarchy {
   body {
     color: $body-font-color;
+    line-height: $type-line-height;
+    font-weight: 400;
+    font-kerning: normal;
+    font-style: normal;
+    margin: 0;
   }
 
   h1,
@@ -18,6 +23,9 @@
   h6,
   p {
     margin: 0;
+    line-height: $type-line-height;
+    font-weight: 400;
+    font-kerning: normal;
   }
 
   @include gen-type-hierarchy();

--- a/vendor/assets/stylesheets/fenrir/tools/_helper-functions.scss
+++ b/vendor/assets/stylesheets/fenrir/tools/_helper-functions.scss
@@ -6,12 +6,12 @@
 //-----------------------------------\\
 
 @function type-size($key, $nth) {
-  @if map-has-key($type-sizes, $key) {
-    $get-key: map-get($type-sizes, $key);
+  @if map-has-key($type-objects, $key) {
+    $get-key: map-get($type-objects, $key);
     @return nth($get-key, $nth);
   }
 
-  @warn "Unknown `#{$key}` in $type-sizes.";
+  @warn "Unknown `#{$key}` in $type-objects.";
   @return null;
 }
 


### PR DESCRIPTION
**Purpose**: Type objects now just resets styling and set sizing of typography. The included `o-text--('variant');` mixin can be used to create type components with custom styling based on the default hierarchy.